### PR TITLE
change to process pid

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 5.3.0 (20231215)
+========================
+- Improved handling of input, assimilation, and restard data to allow multiple, parallel runs on the same input data. The improved approach generates temporary copies of inpit files using process PID to avoid problems with concurrent reading of the same netCDF file.
+
 Version 5.2.0 (20230208)
 ========================
 - Improved handling of restard data, with a more rigorous check on the existence of both file and NC layers to avoid spurious results

--- a/S3M_Main.f90
+++ b/S3M_Main.f90
@@ -2,11 +2,11 @@
 ! S3M
 !***********************************************************************************
 !
-! brief		S3M Snow Multidata Mapping and Modeling (Boni et al. 2010, Avanzi et al. 2022)
+! brief		S3M Snow Multidata Mapping and Modeling (Avanzi et al. 2022)
 !
 ! history	FRANCESCO AVANZI (CIMAFOUNDATION) 
-!+ 		09/02/2023
-!+		v5p2r0
+!+ 		15/12/2023
+!+		v5p3r0
 !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,7 +34,7 @@
 ! 4) Snow age, albedo, melt, and snowpack runoff
 ! 5) Ice thickness.
 
-! S3M 5.2.0 is distributed through the CIMA Research Foundation - Department of Hydrology and Hydraulics GitHub repo at
+! S3M 5.3.0 is distributed through the CIMA Research Foundation - Department of Hydrology and Hydraulics GitHub repo at
 ! https://github.com/c-hydro 
 ! A complete manual regarding model installation, run, as well as pre- and post-processing can be found at: 
 ! https://gmd.copernicus.org/articles/15/4853/2022/
@@ -42,7 +42,7 @@
 !-----------------------------------------------------------------------------------
 ! COMMAND LINE (example)
 !-----------------------------------------------------------------------------------
-! ./S3M_v5p2.x --> parameter(s): S3M_info_domain_DataDa_DataA.txt 
+! ./S3M_v5p3.x --> parameter(s): S3M_infofile.txt 
 !
 ! All compiling and debugging options for S3M are described at https://github.com/c-hydro/hmc-dev
 !

--- a/S3M_Module_Info_Gridded.f90
+++ b/S3M_Module_Info_Gridded.f90
@@ -3,7 +3,7 @@
 ! Author(s): Fabio Delogu, Francesco Silvestro, Simone Gabellani, Francesco Avanzi.
 !
 ! Created on May, 20 2014, 9:57 AM
-! Last update on October 26, 2020 03:00 PM
+! Last update on December 15, 2023 03:00 PM
 !
 ! Module to get info gridded
 !------------------------------------------------------------------------------------
@@ -27,7 +27,8 @@ module S3M_Module_Info_Gridded
                                             S3M_Tools_Generic_UnzipFile, &
                                             reshape2DVar, &
                                             filter_array_unique, &
-                                            filter_array_condition
+                                            filter_array_condition, &
+                                            S3M_Tools_Generic_RemoveFile
 #ifdef LIB_NC
     use S3M_Module_Tools_IO,        only:   S3M_Tools_IO_Get2d_NC, &
                                             check
@@ -326,6 +327,8 @@ contains
                 call check( nf90_get_att(iFileID, nf90_global, "nrows", iRows) )
                 ! Close netCDF file
                 call check( nf90_close(iFileID) )
+                call S3M_Tools_Generic_RemoveFile(oS3M_Namelist(iID)%sCommandRemoveFile, &
+                                                  sFileName, .false.) 
                 ! Info
                 call mprintf(.true., iINFO_Main, ' Define forcing data dims ... OK')
                 
@@ -545,6 +548,8 @@ contains
                     
                     ! Close nc file
                     call check( nf90_close(iFileID) )
+                    call S3M_Tools_Generic_RemoveFile(oS3M_Namelist(iID)%sCommandRemoveFile, &
+                                                  sFileName, .false.) 
                     
                     ! Info
                     call mprintf(.true., iINFO_Main, ' Define forcing geographical data  ... OK ')

--- a/S3M_Module_Tools_Generic.f90
+++ b/S3M_Module_Tools_Generic.f90
@@ -1,8 +1,9 @@
 !------------------------------------------------------------------------------------------     
 ! File:   S3M_Module_Tools_Generic.f90
-! Author: Fabio Delogu.
+! Author: Fabio Delogu, Francesco Avanzi.
 !
 ! Created on March 24, 2014, 1:25 PM
+! Last update on Dec 15, 2023 09:30 AM
 !
 ! Module to define generic tools
 !------------------------------------------------------------------------------------------
@@ -21,6 +22,21 @@ module S3M_Module_Tools_Generic
     !------------------------------------------------------------------------------------------
     
 contains     
+
+    !------------------------------------------------------------------------------------
+    ! Method to get process PID 
+    function getProcessID() result(str)
+        implicit none
+   
+        character(len=256)               :: str
+        integer(kind = 4)               ::  pid
+
+        ! Get Process ID
+        pid = getpid() 
+        write (str, "(I10)") pid !length of PID number to be checked!!if different from I5 does not work
+            
+    endfunction getProcessID
+    !------------------------------------------------------------------------------------
     
     !------------------------------------------------------------------------------------
     ! Method to filter data and return only the unique values from vec

--- a/S3M_infofile.txt
+++ b/S3M_infofile.txt
@@ -8,7 +8,7 @@
 sDomainName = 'vda'
 
 ! Debug flag set (iDEBUG = 0; iDEBUG = 1)
-iFlagDebugSet = 0
+iFlagDebugSet = 1
 ! Debug flag level (iNFO_Basic = 0; iINFO_Main = 1; iINFO_Verbose = 2; iINFO_Extra = 3)
 iFlagDebugLevel = 3
 
@@ -20,7 +20,7 @@ iFlagTypeData_Updating_Gridded = 3
 iFlagTypeData_Ass_SWE_Gridded = 3
 
 ! Restart a run (1 = yes; 0 = no)
-iFlagRestart = 0
+iFlagRestart = 1
 ! Computing snow assimilation MODIS + Snow Height (1 = yes; 0 = no)
 iFlagSnowAssim = 1
 ! Computing snow assimilation of SWE (1 = yes; 0 = no)
@@ -32,7 +32,7 @@ iFlagThickFromTerrData = 1
 ! Apply GlacierDebris Mask (0 = no; 1 = yes)
 iFlagGlacierDebris = 0
 ! Output mode (0 = basic output layers; 1 = extended, all layers -- much slower)
-iFlagOutputMode = 0
+iFlagOutputMode = 1
 ! Assimilate only positive differences (0 = no; 1 = yes)
 iFlagAssOnlyPos = 0
 ! -----------------------------------------------------------------------------------------------
@@ -48,7 +48,7 @@ a1iDimsForcing = 206, 446
 
 ! DT INFO ---------------------------------------------------------------------------------------
 ! Simulation length [hours]
-iSimLength = 8760
+iSimLength = 240
 ! Model dT [seconds]
 iDtModel = 3600
 ! Data forcing gridded dT [seconds]
@@ -72,28 +72,28 @@ iScaleFactor_SWEass = 10
 
 ! TIME INFO -------------------------------------------------------------------------------------
 ! Start time (yyyymmddHHMM format)
-sTimeStart = 201709010000
+sTimeStart = 202301010000
 ! Re-start time (yyyymmddHHMM format)
-sTimeRestart = 201708312300
+sTimeRestart = 202212312300
 ! -----------------------------------------------------------------------------------------------
 
 ! PATH(S) INFO ----------------------------------------------------------------------------------
 ! DATA STATIC
 ! Static gridded data path [Variable(s) --> DEM, CN]
-sPathData_Static_Gridded = '/home/Terrain/'
+sPathData_Static_Gridded = '/home/francesco/Documents/NetBeans_Dev/S3M/dati/static/'
 
 ! DATA DYNAMIC
 ! Forcing gridded data path [Variable(s) --> Rain, AirTemperature, IncRadiation, RelHumidity]
-sPathData_Forcing_Gridded = '/home/$yyyy/$mm/$dd/'
+sPathData_Forcing_Gridded = '/home/francesco/Documents/NetBeans_Dev/S3M/dati/dynamic/$yyyy/$mm/$dd/'
 
 ! Updating gridded data path [Variable(s) --> SnowCoverArea, SnowQuality, SnowMask, SnowHeight, SnowKernel]
-sPathData_Updating_Gridded = '/home/$yyyy/$mm/$dd/'
+sPathData_Updating_Gridded = '/home/francesco/Documents/NetBeans_Dev/S3M/dati/updating/$yyyy/$mm/$dd/'
 
 ! Output gridded data path
-sPathData_Output_Gridded = '/home/$yyyy/$mm/$dd/'
+sPathData_Output_Gridded = '/home/francesco/Documents/NetBeans_Dev/S3M/output/$yyyy/$mm/$dd/'
 
 ! Restart gridded data path
-sPathData_Restart_Gridded = '/home/Restart_240/'
+sPathData_Restart_Gridded = '/home/francesco/Documents/NetBeans_Dev/S3M/dati/restart/'
 
 ! SWE assimilation gridded data path [Variable(s) --> SWE coming from external source, ex. ARPA VdA]
 sPathData_SWE_Assimilation_Gridded = '/home/$yyyy/$mm/$dd/'
@@ -170,11 +170,11 @@ dRhoW = 1000
 
 ! INFO MODEL ------------------------------------------------------------------------------------
 ! Release version     (x.x.x)
-sReleaseVersion = '5.2.0'
+sReleaseVersion = '5.3.0'
 ! Author(s)         (Surname N.)
 sAuthorNames = 'Avanzi F., Gabellani S., Delogu F., Silvestro F.'
 ! Release Date      (yyyy/mm/dd)
-sReleaseDate = '2023/02/09'
+sReleaseDate = '2023/12/15'
 ! -----------------------------------------------------------------------------------------------
 
 /

--- a/configure.sh
+++ b/configure.sh
@@ -3,8 +3,8 @@
 #-----------------------------------------------------------------------------------------
 # Script option(s)
 Script="S3M Library Builder"
-Version="1.0.0"
-Date='2020/11/18'
+Version="1.1.0"
+Date='2023/12/14'
 
 # Other option(s)
 Archive_Default="s3m_model-apps_codes_5.2.0.tar.gz"
@@ -15,7 +15,7 @@ Lib_Dir_Exec_Default="$Lib_Dir_Deps_Default/s3m"
 # Compilation Mode
 Lib_Building_Default=false
 # Executable name
-Exec_Default='S3M_Model_V5_2_0.x'
+Exec_Default='S3M_Model_V5_3_0.x'
 #-----------------------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------------------


### PR DESCRIPTION
Improved handling of input, assimilation, and restard data to allow multiple, parallel runs on the same input data. The improved approach generates temporary copies of inpit files using process PID to avoid problems with concurrent reading of the same netCDF file.